### PR TITLE
elementary Loki Theme

### DIFF
--- a/lib/tokamak-terminal.coffee
+++ b/lib/tokamak-terminal.coffee
@@ -115,6 +115,7 @@ module.exports =
           default: 'standard'
           enum: [
             'standard',
+            'elementary-loki',
             'inverse',
             'grass',
             'homebrew',

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -12,4 +12,5 @@
   @import 'themes/silver-aerogel';
   @import 'themes/solid-colors';
   @import 'themes/dracula';
+  @import 'themes/elementary-loki';
 }

--- a/styles/themes/elementary-loki.less
+++ b/styles/themes/elementary-loki.less
@@ -1,0 +1,15 @@
+.elementary-loki {
+  background-color: rgba(37, 46, 50, 0.95);
+  color: #94a3a5;
+
+  /* to accurately reflect pantheon terminal */
+  line-height: normal;
+
+  ::selection {
+    background-color: #94a3a5;
+  }
+
+  .terminal-cursor {
+    background-color: #839496;
+  }
+}


### PR DESCRIPTION
This theme references the colors used by Pantheon Terminal in elementary OS 0.4, Loki.

Due to #8, it is not currently possible to offer ANSI color choices in a theme, which significantly restricts what is possible to theme. The ANSI color mappings for Pantheon Terminal [are available here on JSBin](https://output.jsbin.com/repala/).